### PR TITLE
Omit skybox from reflection and dim water reflections

### DIFF
--- a/WaterPlane.js
+++ b/WaterPlane.js
@@ -23,7 +23,7 @@ export class WaterPlane {
         gl.bindBuffer(gl.ARRAY_BUFFER, this.buf);
         gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(this.verts), gl.STATIC_DRAW);
     }
-    draw(waveTex, time, mvp, reflectionTex, refractionTex, screenSize) {
+    draw(waveTex, time, mvp, reflectionTex, refractionTex, screenSize, reflectionIntensity = 1.0) {
         const gl = this.gl;
         gl.useProgram(this.program);
 
@@ -50,6 +50,7 @@ export class WaterPlane {
         gl.uniform1f(gl.getUniformLocation(this.program, 'u_time'), time);
         gl.uniformMatrix4fv(gl.getUniformLocation(this.program, 'u_modelViewProjection'), false, mvp);
         gl.uniform2f(gl.getUniformLocation(this.program, 'screenSize'), screenSize[0], screenSize[1]);
+        gl.uniform1f(gl.getUniformLocation(this.program, 'reflectionIntensity'), reflectionIntensity);
 
         gl.drawArrays(gl.TRIANGLES, 0, 6);
     }

--- a/main.js
+++ b/main.js
@@ -113,24 +113,29 @@ function render(time) {
     const reflectedEye = [eye[0], -eye[1], eye[2]];
     const viewRef = mat4.create();
     mat4.lookAt(viewRef, reflectedEye, [0,0,0], [0,-1,0]);
-    const skyboxViewRef = mat4.clone(viewRef);
-    skyboxViewRef[12]=skyboxViewRef[13]=skyboxViewRef[14]=0;
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, reflectionFbo);
     gl.viewport(0,0,canvas.width,canvas.height);
     gl.clearColor(0.0, 0.0, 0.0, 1.0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    skybox.draw(skyboxViewRef, proj, reflectionFbo, canvas.width, canvas.height);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, reflectionFbo);
+
+    const viewProjRef = mat4.create();
+    mat4.multiply(viewProjRef, proj, viewRef);
+
     const starModelRef = mat4.create();
     mat4.translate(starModelRef, starModelRef, [0,5,0]);
     mat4.scale(starModelRef, starModelRef, [2,2,2]);
-    const normalRef = mat3.create();
-    mat3.normalFromMat4(normalRef, starModelRef);
-    const viewProjRef = mat4.create();
-    mat4.multiply(viewProjRef, proj, viewRef);
-    star.draw(starModelRef, viewProjRef, normalRef, starMaterials, lightDir, reflectedEye);
+    const starNormalRef = mat3.create();
+    mat3.normalFromMat4(starNormalRef, starModelRef);
+    star.draw(starModelRef, viewProjRef, starNormalRef, starMaterials, lightDir, reflectedEye);
+
+    const boxModelRef = mat4.create();
+    mat4.translate(boxModelRef, boxModelRef, [4,-5,5]);
+    mat4.scale(boxModelRef, boxModelRef, [2,2,2]);
+    const boxNormalRef = mat3.create();
+    mat3.normalFromMat4(boxNormalRef, boxModelRef);
+    treasureBox.draw(boxModelRef, viewProjRef, boxNormalRef, boxMaterials, lightDir, reflectedEye);
+
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
 
     // ----- Main scene -----
@@ -166,7 +171,8 @@ function render(time) {
         mvp,
         reflectionFboTex,
         refractionTex,
-        [canvas.width, canvas.height]
+        [canvas.width, canvas.height],
+        0.5
     );
 
     requestAnimationFrame(render);

--- a/shaders/waterEffect.frag
+++ b/shaders/waterEffect.frag
@@ -10,6 +10,7 @@ uniform float     u_time;
 uniform float     u_scale;
 uniform float     lodBias;
 uniform vec2      screenSize;
+uniform float     reflectionIntensity;
 
 // GLSL ES 3.0 compatible LOD approximation
 float getManualLod(vec2 uv, float textureSize)
@@ -38,8 +39,10 @@ void main()
     vec2 screenUV = gl_FragCoord.xy / screenSize;
     vec2 distort = vec2(wave1, wave2) - 0.5;
     distort *= 1.0; // distortion scale
-    vec3 refractColor = texture(refractionTex, distort).rgb;
+    vec2 refractUV = clamp(screenUV + distort, 0.0, 1.0);
+    vec3 refractColor = texture(refractionTex, refractUV).rgb;
     vec3 reflectColor = texture(reflectionTex, screenUV).rgb;
+    reflectColor = clamp(reflectColor * reflectionIntensity, 0.0, 0.8);
 
     vec3  water = refractColor + vec3(moire);
     vec3 finalColor = mix(water, reflectColor, 0.30);


### PR DESCRIPTION
- exclude skybox from reflection framebuffer to avoid overbright clouds
- add reflectionIntensity uniform to clamp reflection colour
- draw all scene geometry into reflection FBO so reflections include dynamic models
- sample refraction texture using screen UVs so refracted models aren't flipped
